### PR TITLE
message.js: Remove console.log in _sign()

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -39,7 +39,6 @@ Message.prototype.magicHash = function magicHash() {
 };
 
 Message.prototype._sign = function _sign(privateKey) {
-  console.log(privateKey);
   $.checkArgument(privateKey instanceof PrivateKey,
     'First argument should be an instance of PrivateKey');
   var hash = this.magicHash();


### PR DESCRIPTION
Please fix this (rather soon), as leaking private keys to the console is never a good idea.